### PR TITLE
add argument support for `flamegraph`

### DIFF
--- a/cmd/flamegraph
+++ b/cmd/flamegraph
@@ -5,6 +5,7 @@
  */
 
 var mod_bunyan = require('bunyan');
+var mod_getopt = require('posix-getopt');
 var mod_stackvis = require('../lib/stackvis');
 
 var log = new mod_bunyan({
@@ -15,14 +16,22 @@ var log = new mod_bunyan({
 var reader = new mod_stackvis.readerLookup('collapsed');
 var writer = new mod_stackvis.writerLookup('flamegraph-svg');
 
-var args = {};
+var parser = new mod_getopt.BasicParser('x:', process.argv);
 
-for (var i = 2; i < process.argv.length; i++) {
-    var arg = process.argv[i];
-    var eq = arg.indexOf('=');
-    if (eq < 0)
-        continue;
-    args[arg.substr(0, eq)] = arg.substr(eq + 1);
+var args = {};
+while ((option = parser.getopt()) !== undefined) {
+    switch (option.option) {
+        case 'x':
+            var arg = option.optarg;
+            var eq = arg.indexOf('=');
+            if (eq < 0)
+                break;
+            args[arg.substr(0, eq)] = arg.substr(eq + 1);
+            break;
+        default:
+            process.exit(1);
+            break;
+      }
 }
 
 mod_stackvis.pipeStacks(log, process.stdin, reader, writer, process.stdout,

--- a/lib/stackvis.js
+++ b/lib/stackvis.js
@@ -3,6 +3,7 @@
  */
 
 var mod_assert = require('assert');
+var mod_jsprim = require('jsprim');
 
 exports.readerLookup = readerLookup;
 exports.writerLookup = writerLookup;
@@ -88,10 +89,11 @@ function pipeStacks(log, instream, readercons, writer, outstream, args, callback
 			return;
 		}
 
-		args.stacks = stacks;
-		args.output = outstream;
-		args.log = log;
-		writer.emit(args, function (err2) {
+		var _args = jsprim.deepCopy(args);
+		_args.stacks = stacks;
+		_args.output = outstream;
+		_args.log = log;
+		writer.emit(_args, function (err2) {
 			/*
 			 * It's stupid that we need to check whether we're
 			 * writing to stdout, but this is the same thing Node's

--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
 		"node-uuid": "1.4.1",
 		"posix-getopt": "1.0.0",
 		"vasync": "1.4.0",
-		"verror": "1.3.6"
+		"verror": "1.3.6",
+		"jsprim": "0.5.1"
 	},
 	"license": "MIT"
 }


### PR DESCRIPTION
# summary

this adds the extremely rudimentary ability to pass args from the `flamegraph` command line tool, to the `svg` outputter.  It works like:

```
$ flamegraph width=2500 title='Hello World' ...
```

this is related to https://github.com/davepacheco/node-stackvis/issues/10
# issues

this approach is nice because the user can specify arbitrary attributes that are passed as `args` to the backend function, so it won't be needed to be changed if the backend ever supports new options.  However, it's pretty dirty, the best approach would probably be to incorporate `posix-getopt` in this tool, and specify the options explicitly instead of using the approach in the PR.
