### PR TITLE
update manta dep

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
 		"bunyan": "0.21.4",
 		"carrier": "0.1.7",
 		"hogan.js": "2.0.0",
-		"manta": "1.1.2",
+		"manta": "1.5.1",
 		"node-uuid": "1.4.1",
 		"posix-getopt": "1.0.0",
 		"vasync": "1.4.0",


### PR DESCRIPTION
fixes this on node 12

```
# dtrace -n 'profile-97/pid == $target/{ @[ustack(80, 8192)] = count(); }' -c ./prog.sh | stackvis | stackvis share
timers.js:165
    throw new TypeError('msecs must be a number');
          ^
TypeError: msecs must be a number
```