### PR TITLE
Use Semicolon Separator In Collapsed Output

### DIFF
--- a/lib/input-collapsed.js
+++ b/lib/input-collapsed.js
@@ -24,7 +24,7 @@ function CollapsedStreamReader(input, log)
 			return;
 		}
 
-		reader.emit('stack', match[1].split(','),
+		reader.emit('stack', match[1].split(';'),
 		    parseInt(match[2], 10));
 	});
 	this.csr_carrier.on('end', function () { reader.emit('end'); });

--- a/lib/output-collapsed.js
+++ b/lib/output-collapsed.js
@@ -22,6 +22,6 @@ exports.emit = function emitCollapsed(args, callback)
 	    'required "output" argument must be a function');
 
 	args.stacks.eachStackByCount(function (frames, count) {
-		process.stdout.write(frames.join(',') + ' ' + count + '\n');
+		process.stdout.write(frames.join(';') + ' ' + count + '\n');
 	});
 };


### PR DESCRIPTION
Use semicolon separator in collapsed output for compatibility with
FlameGraph.  Allows collapsed output from stackvis to be read by flamegraph.pl.