### PR TITLE
Fix Collapsed Output

### DIFF
--- a/lib/output-collapsed.js
+++ b/lib/output-collapsed.js
@@ -22,6 +22,7 @@ exports.emit = function emitCollapsed(args, callback)
 	    'required "output" argument must be a function');
 
 	args.stacks.eachStackByCount(function (frames, count) {
-		process.stdout.write(frames.join(',') + ' ' + count + '\n');
+		args.output.write(frames.join(',') + ' ' + count + '\n');
 	});
+	callback();
 };


### PR DESCRIPTION
Fix collapsed output to write to the stream passed rather than always
writing to stdout.

Call passed callback when done.