### PR TITLE
Bump dependencies for Node.js v4 support

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,10 +15,10 @@
 		"url": "git://github.com/davepacheco/node-stackvis.git"
 	},
 	"dependencies": {
-		"bunyan": "0.21.4",
+		"bunyan": "1.8.1",
 		"carrier": "0.1.7",
 		"hogan.js": "2.0.0",
-		"manta": "1.5.1",
+		"manta": "3.0.0",
 		"node-uuid": "1.4.1",
 		"posix-getopt": "1.0.0",
 		"vasync": "1.4.0",


### PR DESCRIPTION
This bumps the following dependencies:

- bunyan 0.21.4 -> 1.8.1
- manta 1.5.1 -> 3.0.0

In both cases the dependencies are upgraded to a major version, so some caution is warranted when reviewing this.

Also, I wasn't sure if, given the above,  the version of stackvis should be updated to 1.0.0 (from 0.3.0)

There wasn't a suite of tests to run (make test), so I'd like some input on testing. 